### PR TITLE
Use 2-argument version of STOP_TEST for compatibility with GAP 4.8

### DIFF
--- a/tst/d8.tst
+++ b/tst/d8.tst
@@ -48,4 +48,4 @@ gap> Size(Ex);
 
 #
 gap> SetInfoLevel(InfoCohomolo,CHMLINFO);
-gap> STOP_TEST( "d8.tst" );
+gap> STOP_TEST( "d8.tst", 10000 );


### PR DESCRIPTION
Otherwise the following happens: https://travis-ci.org/gap-system/gap-docker-pkg-tests-stable/jobs/309183299

As soon as GAP 4.9 will be out, packages may start to remove 2nd arguments from calls of `STOP_TEST`.