### PR TITLE
removed hardcoded gcc, do not overwrite CFLAGS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - env: CC=clang CXX=clang++
       compiler: clang
     - env:
-      compiler: gcc
+      compiler: clang 
     - env: ABI=32
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - env: CC=clang CXX=clang++
       compiler: clang
     - env:
-      compiler: clang 
+      compiler: gcc
     - env: ABI=32
 
 branches:

--- a/Makefile.in
+++ b/Makefile.in
@@ -2,8 +2,7 @@
 # all executables are put into the bin directory.
 BIN = bin/@GAPARCH@
 
-CC=gcc
-CFLAGS = -O
+CFLAGS += -O
 
 # many cohomolo symbols (e.g. 'exp') clash with C builtins,
 # so we disable them to avoid spurious warnings and errors

--- a/standalone/progs.d/findpres/makefile
+++ b/standalone/progs.d/findpres/makefile
@@ -1,5 +1,4 @@
-CC = gcc
-CFLAGS= -O2
+CFLAGS += -O2
 all:  makegp gprun conrun grrun
 .c.o:
 	${CC} -c $(CFLAGS) $*.c 

--- a/standalone/progs.d/makefile
+++ b/standalone/progs.d/makefile
@@ -1,5 +1,4 @@
-CC = gcc
-CFLAGS= -O -fno-builtin
+CFLAGS += -O -fno-builtin
 BIN= ../exec.d
 gap:    ${BIN}/gprun ${BIN}/egrun ${BIN}/sylrun ${BIN}/normrun ${BIN}/conrun\
 	${BIN}/pcrun ${BIN}/scrun ${BIN}/selgen ${BIN}/matcalc ${BIN}/nqmrun\


### PR DESCRIPTION
also, allow a Travis test to be run with clang, not gcc