### PR TITLE
Warning eliminations

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -16,7 +16,6 @@ EXTRA_CFLAGS += -fno-builtin
 # tempting to reimplement this all in scratch in a modern C or C++,
 # or a radically different language (Ruse, Go, Julia, ...)
 EXTRA_CFLAGS += -Wno-implicit-function-declaration
-EXTRA_CFLAGS += -Wno-dangling-else
 EXTRA_CFLAGS += -Wno-unused-result
 
 all:

--- a/Makefile.in
+++ b/Makefile.in
@@ -16,7 +16,6 @@ EXTRA_CFLAGS += -fno-builtin
 # tempting to reimplement this all in scratch in a modern C or C++,
 # or a radically different language (Ruse, Go, Julia, ...)
 EXTRA_CFLAGS += -Wno-implicit-function-declaration
-EXTRA_CFLAGS += -Wno-return-type
 EXTRA_CFLAGS += -Wno-dangling-else
 EXTRA_CFLAGS += -Wno-unused-result
 

--- a/standalone/progs.d/conpdc2.c
+++ b/standalone/progs.d/conpdc2.c
@@ -81,6 +81,7 @@ cnprg2 (void)
   for (i=1;i<=k;i++) while ((c=getc(ip))!='\n');
   op=fopen(temp1,"w"); fprintf(op,"%4d%4d%4d%4d\n",ind,ncp,0,0);
 
+  ngth=0;
   while (1)
   { for (pno=1;pno<=ncp;pno++)
     { printf("Converting perm no %d.\n",pno);

--- a/standalone/progs.d/exb.c
+++ b/standalone/progs.d/exb.c
@@ -13,7 +13,7 @@ extern short invg[],mwdl,endr,*fpt,*bpt,nelim,lo,**imcos,dim,
 
 int 
 scanrel (void)
-{ short i,j,k,l,m,necr,*s,*t; short compfsc,*p,*q,*r,esc;
+{ short i,j,k,l,m,necr,*s,*t; short compfsc,*p,*q,esc;
   fullsc=1; stcr=endcr+2; endcr+=(1+rel[stcr-1]); esc=0;
   *wd1=0; *wd2=0; p=wd1+mwdl; q=p+dim;
   while (++p<=q) *p=0;

--- a/standalone/progs.d/exc.c
+++ b/standalone/progs.d/exc.c
@@ -177,7 +177,7 @@ int
 ainvb (short *a, short *b, short *c)
 /* Concatenate word+vector "a" with inverse of word+vector "b" and write into c
 */
-{ short min,canct,n,*p,*q,*r,*c1,*ce,*a1;
+{ short min,canct,*p,*q,*r,*c1,*ce,*a1;
   min= (*a<= *b) ? *a : *b;
   p=a+1; q=b+1; canct=0;
   while (canct<min && *p== *q) {canct++; p++; q++; }

--- a/standalone/progs.d/gpp.c
+++ b/standalone/progs.d/gpp.c
@@ -57,7 +57,7 @@ gpprog (void)
     seek=jobt; given=jobt; ordknown=1;
     for (i=1;i<=jobt;i++)  fscanf(ip,"%hd",order+i);
   }
-  else ordknown=0;
+  else { seek=0; given=0; ordknown=0; }
 
 /* Now we read the generating permutations */
   np2=2*nperms-2;
@@ -106,6 +106,7 @@ loop:
       bno--; if (bno==0) goto foundorder; goto loop;
     }
   }
+  else cord=0;
 /* Now we start generating the Schreier generators that fix the firat bno
    base points, test them for membership, and add them as new generators
    if necessary.

--- a/standalone/progs.d/grp.c
+++ b/standalone/progs.d/grp.c
@@ -54,7 +54,7 @@ grprog (void)
   for (i=0;i<dnwds;i++) done[i]=def+maxcos*(i+1);
 
   if (gap) {op=fopen(outfg,"w"); fprintf(op,"COHOMOLO.PermRels := [\n");}
-  nr=0; endr= -1;
+  mini=0; nr=0; endr= -1;
   for (bno=nb;bno>=1;bno--)
   { printf("bno=%d.\n",bno);
 /* We are going to do a coset enumeration of the group G[bno] (in the stabilizer

--- a/standalone/progs.d/matfns.c
+++ b/standalone/progs.d/matfns.c
@@ -137,7 +137,7 @@ int cbdef (int gb, int ge, int cbno, short *d1, short *d2, short *wt, short *acl
    1 is returned if mat[cbno] is the identity, otherwise 0.
   Externals: mat,spv,prime,dim.
 */
-{ short i,j,k,l,fac,w,*ar,*are,*p,**cbm; int sum;
+{ short i,j,k,l,fac,*ar,*are,*p,**cbm; int sum;
   char id;
   cbm=mat[cbno];
   for (i=1;i<=dim;i++)
@@ -150,7 +150,7 @@ restart:
   for (i=1;i<=dim;i++) for (j=gb;j<=ge;j++)
   { k=comm(cbm[i],spv,mat[j]);
     while (k>0) if (wt[k]<=wt[i] || (d1[k]==0 && wt[k]==wt[i]+1))
-    { w=wt[k]; wt[k]=wt[i]+1;
+    { wt[k]=wt[i]+1;
       if (wt[k]> *acl) *acl=wt[k];
       if (id && spv[k]!=1) id=0;
       if (id) for (l=k+1;l<=dim;l++) if (spv[l]>0) id=0;

--- a/standalone/progs.d/mcp.c
+++ b/standalone/progs.d/mcp.c
@@ -218,28 +218,29 @@ conprog (int con)
       for (n=dim;n>=1;n--)
       { cv=mat[lm3][1]; cve=cv+dim; cc=mat[lm3][2];
         for (i=dim;i>=1;i--) if (bcf[i]==0)
-        if (n==1) {p=cbm[1]; q=p+dim; while (++p<=q) *p=0; cbm[1][i]=1; break;}
-        else
-        { bn=i; p=cv;
-          while (++p<=cve) *p=0;
-          cv[i]=1;
-          while(1)
-          { for (j=1;j<=nperms;j++)
-            { comm(cv,cc,mat[nm2+j]);
-              for (k=dim;k>n;k--) if ((fac=cc[ibcf[k]])!=0)
-              { p=cc; r=p+dim; q=cbm[k]+1;
-                while (++p<=r)
-                { sum= *p-(fac* *q); *p=sum%prime; if (*p<0) *p+=prime; q++; }
+	{ if (n==1) {p=cbm[1]; q=p+dim; while (++p<=q) *p=0; cbm[1][i]=1; break;}
+          else
+          { bn=i; p=cv;
+            while (++p<=cve) *p=0;
+            cv[i]=1;
+            while(1)
+            { for (j=1;j<=nperms;j++)
+              { comm(cv,cc,mat[nm2+j]);
+                for (k=dim;k>n;k--) if ((fac=cc[ibcf[k]])!=0)
+                { p=cc; r=p+dim; q=cbm[k]+1;
+                  while (++p<=r)
+                  { sum= *p-(fac* *q); *p=sum%prime; if (*p<0) *p+=prime; q++; }
+                }
+                for (k=dim;k>0;k--) if (cc[k]!=0)
+                { bn=k; id=0; sw=cv; cv=cc; cc=sw; cve=cv+dim; break;}
+                if (k>0) break;
               }
-              for (k=dim;k>0;k--) if (cc[k]!=0)
-              { bn=k; id=0; sw=cv; cv=cc; cc=sw; cve=cv+dim; break;}
-              if (k>0) break;
+              if (j>nperms) break;
             }
-            if (j>nperms) break;
-          }
-          bcf[bn]=n; ibcf[n]=bn; p=cbm[n]; q=p+dim; r=cv+1;  fac=pinv[cv[bn]];
-          while (++p<=q) {sum= *r*fac; *p=sum%prime; r++; }
-          break;
+            bcf[bn]=n; ibcf[n]=bn; p=cbm[n]; q=p+dim; r=cv+1;  fac=pinv[cv[bn]];
+            while (++p<=q) {sum= *r*fac; *p=sum%prime; r++; }
+            break;
+	  }
         }
       }
     }

--- a/standalone/progs.d/mcp.c
+++ b/standalone/progs.d/mcp.c
@@ -10,6 +10,59 @@ FILE *ip,*op;
 
 void seeknln (void) { while (getc(ip)!='\n'); }
 
+/* We repeat a few procedures from permfns.c, since that file is not loaded
+   in matcalc.
+*/
+void
+addsv (int pt, short *sv)
+{ short pn;
+  pn=sv[pt];
+  while (pn!= -1)
+  { (*cp)++; cp[*cp]=pn; pt=pptr[pn][pt]; pn=sv[pt]; }
+}
+
+void
+invert (short *ptr1, short *ptr2)
+{ short i;
+  for (i=1;i<=npt;i++) ptr2[ptr1[i]]=i;
+}
+
+int
+image (int pt)
+{ short i;
+  for (i=1;i<= *cp;i++) pt=pptr[cp[i]][pt];
+  return(pt);
+}
+
+void
+readvec (short *ptr, int e)
+{ short i; for (i=1;i<=npt+e;i++) fscanf(ip,"%hd",ptr+i); }
+
+void
+readbaselo (int nb, short *base, short *lorb)
+{ short i;
+  for (i=1;i<=nb;i++) fscanf(ip,"%hd",base+i);
+  for (i=1;i<=nb;i++) fscanf(ip,"%hd",lorb+i);
+}
+
+void
+readpsv (int e, int nb, int nperms, short **svptr)
+{ short i,j,*k;
+  for (i=1;i<=nperms;i++)
+  { j=e+2*i-2; readvec(pptr[j],1); invert(pptr[j],pptr[j+1]); }
+  for (i=1;i<=nb;i++)
+  { readvec(svptr[i],0);
+    for (j=1;j<=npt;j++) { k=svptr[i]+j; if (*k>0) *k +=e;}
+  }
+}
+
+void setpinv (void)
+{ short i,j;
+  for (i=0;i<prime;i++) pinv[i]=0;
+  for (i=1;i<prime;i++) if (pinv[i]==0) for (j=1;j<prime;j++)
+  if (i*j % prime ==1) { pinv[i]=j; pinv[j]=i; break; }
+}
+
 int mcprog (void)
 { short i,j,k,l,m,n,nperms,np2,*p,**q;
   int quot;
@@ -246,57 +299,4 @@ conprog (int con)
     fclose(ip); fclose(op);
   }
   return(0);
-}
-
-/* We repeat a few procedures from permfns.c, since that file is not loaded
-   in matcalc.
-*/
-int 
-addsv (int pt, short *sv)
-{ short pn;
-  pn=sv[pt];
-  while (pn!= -1)
-  { (*cp)++; cp[*cp]=pn; pt=pptr[pn][pt]; pn=sv[pt]; }
-}
-
-int 
-invert (short *ptr1, short *ptr2)
-{ short i;
-  for (i=1;i<=npt;i++) ptr2[ptr1[i]]=i;
-}
-
-int 
-image (int pt)
-{ short i;
-  for (i=1;i<= *cp;i++) pt=pptr[cp[i]][pt];
-  return(pt);
-}
-
-int 
-readvec (short *ptr, int e)
-{ short i; for (i=1;i<=npt+e;i++) fscanf(ip,"%hd",ptr+i); }
-
-int 
-readbaselo (int nb, short *base, short *lorb)
-{ short i;
-  for (i=1;i<=nb;i++) fscanf(ip,"%hd",base+i);
-  for (i=1;i<=nb;i++) fscanf(ip,"%hd",lorb+i);
-}
-
-int 
-readpsv (int e, int nb, int nperms, short **svptr)
-{ short i,j,*k;
-  for (i=1;i<=nperms;i++)
-  { j=e+2*i-2; readvec(pptr[j],1); invert(pptr[j],pptr[j+1]); }
-  for (i=1;i<=nb;i++)
-  { readvec(svptr[i],0);
-    for (j=1;j<=npt;j++) { k=svptr[i]+j; if (*k>0) *k +=e;}
-  }
-}
-
-int setpinv (void)
-{ short i,j;
-  for (i=0;i<prime;i++) pinv[i]=0;
-  for (i=1;i<prime;i++) if (pinv[i]==0) for (j=1;j<prime;j++)
-  if (i*j % prime ==1) { pinv[i]=j; pinv[j]=i; break; }
 }

--- a/standalone/progs.d/mcp.c
+++ b/standalone/progs.d/mcp.c
@@ -211,7 +211,7 @@ conprog (int con)
     op=fopen(inf6,"w");
     fprintf(op,"%4d%4d%4d\n",prime,dim,2);
     cbm=mat[lmat+1];
-    if (dim==1) { cbm[1][1]=id=1; }
+    if (dim==1) { cbm[1][1]=id=1; icbm=NULL; bcf=NULL; ibcf=NULL; lm3=0; }
     else
     { icbm=mat[lmat+2]; bcf=mat[lmat+4][1]; lm3=lmat+3;
       for (i=1;i<=dim;i++) bcf[i]=0; ibcf=mat[lmat+4][2]; id=1;

--- a/standalone/progs.d/mcp.c
+++ b/standalone/progs.d/mcp.c
@@ -64,7 +64,7 @@ void setpinv (void)
 }
 
 int mcprog (void)
-{ short i,j,k,l,m,n,nperms,np2,*p,**q;
+{ short i,j,k,l,n,nperms,np2,*p,**q;
   int quot;
   if ((ip=fopen(inf1,"r"))==0)
   { fprintf(stderr,"Cannot open %s.\n",inf1); return(-1);}

--- a/standalone/progs.d/normp1.c
+++ b/standalone/progs.d/normp1.c
@@ -176,7 +176,7 @@ nprg1 (void)
   printf("Initial analysis and choice of base.\n");
 
   fpt=0; nint=0; gdone=0; cb=1; nnth=1; heqg=1; nrego=0; nhorbs=0; reginfolen=0;
-  lnth=0; intorb[0][0]=npt;
+  regorep=0; lnth=0; intorb[0][0]=npt;
   for (i=1;i<=npt;i++) cted[i]=0;
   for (i=1;i<=nbg;i++) {intorb[0][i]=gbase[i]; cted[gbase[i]]=1; }
   j=nbg; for (i=1;i<=npt;i++) if (cted[i]==0) {j++; intorb[0][j]=i;}
@@ -194,7 +194,7 @@ nprg1 (void)
     allorbs(glorb2,gorno2);
     skfaithorb(); ct=0; inreg=1; regbno=0; goto L3;
   }
-  inreg=0;
+  ct=0; inreg=0; regbno=0;
 
 L1:
   permnos(sth,npt,nnth); allorbs(glorb1,gorno1);

--- a/standalone/progs.d/normp1.c
+++ b/standalone/progs.d/normp1.c
@@ -30,7 +30,7 @@ FILE *ip,*op;
 int 
 nprg1 (void)
 { char heqg,inreg,con1,con2,fpt;
-  short i,j,k,l,m,n,nnb,endorb,regb,regbno,regorep,rpno,*intno,*tsv,lo,
+  short i,j,k,l,m,regb,regbno,regorep,rpno,*intno,*tsv,lo,
         *ptr,mxb,mxp,mxexp,nph,npg,maxl,ct,*spptr,*opno;
   int rsp,spn,quot;
 /* If we are storing a minimal gen set for H, we read it in */
@@ -471,7 +471,7 @@ newbasept (int hfl)
 int 
 skfaithorb (void)
 /* We seek a possible orbit O1, as described in a comment above. */
-{ short i,j,*k,l,m,n,ct;  char fnd;
+{ short i,j,*k,l,n,ct;  char fnd;
   k=intorb[nint];  fnd=0;
   for (j=1;j<=*k;j++)
   { lrego=glorb2[gorno2[*(k+j)]];

--- a/standalone/progs.d/normp1.c
+++ b/standalone/progs.d/normp1.c
@@ -237,16 +237,17 @@ L2:
     }
     *intorb[nint]=ct; lnth=cb; nnth++;
     if (heqg)
-    if (lorbg[cb]==lorbh[cb])
-    { if (sym==0) { permnos(stg,npt,cb); allorbs(glorb2,gorno2); }
-      if (sym || (*glorb2== *glorb1))
-      { ntorno[cb]=0; endorno[cb]=0;
-        if (gdone)
-        { fprintf(stderr,"H = G.\n"); return(1); }
-        cb++; goto L1;
+    { if (lorbg[cb]==lorbh[cb])
+      { if (sym==0) { permnos(stg,npt,cb); allorbs(glorb2,gorno2); }
+        if (sym || (*glorb2== *glorb1))
+        { ntorno[cb]=0; endorno[cb]=0;
+          if (gdone)
+          { fprintf(stderr,"H = G.\n"); return(1); }
+          cb++; goto L1;
+        }
       }
+      else {ad1=cb;heqg=0;}
     }
-    else {ad1=cb;heqg=0;}
     nhorbs++; ntorno[cb]=nhorbs; endorno[cb]=0;
     horno[nhorbs]=gorno1; hlorb[nhorbs]=glorb1;
     gorno1=glorb1+ *glorb1; glorb1=gorno1+npt1;
@@ -263,7 +264,7 @@ L3:
   { bpt = (inreg) ? rego[j] : intorb[nint][j];
     con1=1; i=stg;
     if (fpt)
-    if (glorb1[gorno1[bpt]]==1) lrego++; else con1=0;
+    { if (glorb1[gorno1[bpt]]==1) lrego++; else con1=0; }
     if (con1) con1 = (sym) ? nonb[bpt] && (gdone==0) : pptr[i][npt1]>=cb;
     while (con1)
     { con2 = (sym) ? 1 : pptr[i][bpt]!=bpt;
@@ -449,11 +450,13 @@ permnos (int no, int uf, int lf)
 int 
 newbasept (int hfl)
 /* Changes gbase[nnth] to bpt, If hfl=1 same for hbase[nnth] */
-{ if (hfl)  if (hbase[nnth] != bpt)
-  { printf("H base no %d changed from %d to %d.\n",nnth,hbase[nnth],bpt);
-    if ((intbase(bpt,nnth,&sth,&nbh,hbase,lorbh,svhptr))== -1) return(-1);
+{ if (hfl)
+  { if (hbase[nnth] != bpt)
+    { printf("H base no %d changed from %d to %d.\n",nnth,hbase[nnth],bpt);
+      if ((intbase(bpt,nnth,&sth,&nbh,hbase,lorbh,svhptr))== -1) return(-1);
+    }
+    else printf("H base no %d remains %d.\n",nnth,hbase[nnth]);
   }
-  else printf("H base no %d remains %d.\n",nnth,hbase[nnth]);
   if (sym==0)
   { if (gbase[cb] != bpt)
     { printf("G base no %d changed from %d to %d.\n",cb,gbase[cb],bpt);

--- a/standalone/progs.d/normp2.c
+++ b/standalone/progs.d/normp2.c
@@ -135,7 +135,7 @@ found (void)
   return(0);
 }
 
-int 
+void
 deforbperm (int bpt, int imbpt)
 /* Update orbit permutation information using fact that tp[bpt]=imbpt. */
 { short i,x,y,z;

--- a/standalone/progs.d/normp2.c
+++ b/standalone/progs.d/normp2.c
@@ -394,23 +394,24 @@ nprg2 (void)
       { imbpt=tp[gbase[adno]];
         if (fail) { m=ntorno[adno]; if (m>0) n=imorno[orhct][imbpt]; }
         if (reg[adno]<=0  || defim[adno]!=imbpt)
-        if (sym==0)
-        { if (expcp[*expcp]<=start[adno])
-          { (*expcp)++; expcp[*expcp]=start[adno]+1; bt=0; }
-          else if (adno>lexp && expcp[*expcp]<start[adno+1])
-          { expcp[*expcp]++; bt=0; }
-          if (adno<=lexp)
-          { sva=svgptr[adno]; ap=adpt+adno; (*ap)++;
-            while (sva[*ap]<=0 && *ap<=npt) (*ap)++;
-            if (*ap<=npt) {bt=0; exprep(*ap,adno,sva); } else bt=1;
+	{ if (sym==0)
+          { if (expcp[*expcp]<=start[adno])
+            { (*expcp)++; expcp[*expcp]=start[adno]+1; bt=0; }
+            else if (adno>lexp && expcp[*expcp]<start[adno+1])
+            { expcp[*expcp]++; bt=0; }
+            if (adno<=lexp)
+            { sva=svgptr[adno]; ap=adpt+adno; (*ap)++;
+              while (sva[*ap]<=0 && *ap<=npt) (*ap)++;
+              if (*ap<=npt) {bt=0; exprep(*ap,adno,sva); } else bt=1;
+            }
           }
-        }
-        else if (expcp[*expcp]<start[adno+1])
-        { j=expcp[*expcp]; inim[j]=0;
-          for (i=j+1;bt;i++)
-          if (inim[i]==0 && (adno!=gskno || i!=gbase[adno]))
-          { expcp[*expcp]=i; bt=0; }
-        }
+          else if (expcp[*expcp]<start[adno+1])
+          { j=expcp[*expcp]; inim[j]=0;
+            for (i=j+1;bt;i++)
+            if (inim[i]==0 && (adno!=gskno || i!=gbase[adno]))
+            { expcp[*expcp]=i; bt=0; }
+          }
+	}
         if (bt)
         { j=ntorno[adno];
           if (j>0)

--- a/standalone/progs.d/normp2.c
+++ b/standalone/progs.d/normp2.c
@@ -86,7 +86,7 @@ setskno (void)
 /* Initialize the "bound" orbit, using bind, as above, and add the relevant
    elements of H to the generators of N.
  */
-  for (i=1;i<=npt;i++) bindor[i]=i; bindor[gbase[gskno]]=0;
+  for (i=1;i<=npt;i++) bindor[i]=i; bindor[gbase[gskno]]=0; n=0;
   for (i=stn;i!= -1;i=fp[i]) {bind(i); (*pno)++; pno[*pno]=i; n=i; }
   k=ntno[adno];
   if (k!=0)
@@ -184,7 +184,7 @@ nprg2 (void)
    orhct and ntct are approximately the values of orhno and ntno for the 
    current adno. First we initialize everything.
 */
-  n=0; ntct=0; orhct=0;
+  j=0; n=0; ntct=0; orhct=0;
   for (i=1;i<nbg;i++)
   { if (ntorno[i] > 0) orhct++; if (ntno[i]>0) ntct++;
 /* regsv is used when we compute automorphism actions of tp on O, as described

--- a/standalone/progs.d/nqfns.c
+++ b/standalone/progs.d/nqfns.c
@@ -369,14 +369,15 @@ loop:
       { exsgn= -1; pex= -1; spc= p1+1; spf=spc+ *p1-2; goto recurse;}
     }
     else if (*e>=prime)
-    if (gen>facexp) *e-=prime;
-    else
+    { if (gen>facexp) *e-=prime;
+      else
 /* Deal with exponent >= prime */
-    { *e -=prime; dp=powptr[gen]; p1= *dp; p2= *(dp+1);
-      if (tails && p2!=0) {fac=sgn; setnr(p2); }
-      if (p1!=0 && *p1!=0)
-      { exsgn=1; pex= -1; pugen=gen; spf= p1+1; spc=spf+ *p1-2;
-        goto recurse;
+      { *e -=prime; dp=powptr[gen]; p1= *dp; p2= *(dp+1);
+        if (tails && p2!=0) {fac=sgn; setnr(p2); }
+        if (p1!=0 && *p1!=0)
+        { exsgn=1; pex= -1; pugen=gen; spf= p1+1; spc=spf+ *p1-2;
+          goto recurse;
+        }
       }
     }
   }
@@ -389,12 +390,13 @@ loop:
     { if (pugen==pgen)
       { spugen[stkp]= -pgen;
         if (ex<0)
-        if (gen>facexp) sex[stkp]=ex+prime;
-        else
-        { sex[stkp]=ex+prime; dp=powptr[gen]; p3= *dp; p4= *(dp+1);
-          if (tails && p4!=0) { fac= -sgn; setnr(p4); }
-          if (p3!=0 && *p3!=0)
-          { exsgn= -1; spc= p3+1; spf=spc+ *p3-2; goto recurse;}
+	{ if (gen>facexp) sex[stkp]=ex+prime;
+          else
+          { sex[stkp]=ex+prime; dp=powptr[gen]; p3= *dp; p4= *(dp+1);
+            if (tails && p4!=0) { fac= -sgn; setnr(p4); }
+            if (p3!=0 && *p3!=0)
+            { exsgn= -1; spc= p3+1; spf=spc+ *p3-2; goto recurse;}
+	  }
         }
       }
       else pugen=pgen;

--- a/standalone/progs.d/nqfns.c
+++ b/standalone/progs.d/nqfns.c
@@ -18,7 +18,7 @@ ingp (int inp)
    procedure. inp=0 when file is already open - i.e. when act=1, and pcp is
    the output from scrun.
 */
-{ int i,j,k,l,sum,jump; short *orpf,*orpb,**pcp,**pcpj,m;
+{ int i,j,k,l,sum,jump; short *orpf,**pcp,**pcpj,m;
   if (inp)
   { ip=fopen(inf1,"r");
     if (ip==0) { fprintf(stderr,"Cannot open %s\n",inf1); return(-1); }
@@ -496,7 +496,7 @@ bgc (void)
 int 
 intgen (int i, int j)
 /* A new generator is introduced for commutator [i,j] or (if i=j) i^p */
-{ short **dp,*p,*nrpb; int sum;
+{ short **dp; int sum;
   dp= (stage) ? comptr[i]+j : (i==j) ? powptr[i] : comptr[i]+2*j;
   if (*dp != 0 && *(*dp-1) != 0)
   { /*printf("Reln [%d,%d] is already a defn.\n",i,j);*/ return(1);}
@@ -529,7 +529,7 @@ intgen (int i, int j)
 int 
 subrel (int i, int j)
 /* Value of [i,j] or i^p is computed using an associativity condition. */
-{ short **dp,*p,*nrpb; int x,y,z;
+{ short **dp; int x,y,z;
   dp= (stage) ? comptr[i]+j : (i==j) ? powptr[i] : comptr[i]+2*j;
   if (*dp != 0 && *(*dp-1) != 0)
   { /*printf("Reln [%d,%d] is already a defn.\n",i,j);*/ return(0);}
@@ -553,7 +553,7 @@ subrel (int i, int j)
 int 
 assoc (int g1, int g2, int g3)
 /* Associativity relation is collected. */
-{ char eq12,eq23,prnt,triv; short *p; int i,l,e,sum;
+{ char eq12,eq23,prnt,triv; short *p; int i,e,sum;
   sum= stage ? exp+dim: exp;
   if (g3<0) {prnt=1; g3= -g3;} else prnt=0;
   eq12= g1==g2; eq23= g2==g3 && g1!=g2;
@@ -589,7 +589,7 @@ prnrel (void)
    or made redundant if necessary.
 */
 { int i,j,k,l,nl,w,x,y,ct,elno,fac,pow,len,gno; short *p,*q,*eprvec,**dp,**edp;
-  char sub,triv,gth,u;
+  char sub,gth,u;
   u= (stage) ? 1 : 0; pow=0; len=0; gno=0;
   for (i=nng;i>=1;i--) if ((x=nexpnt[i])!=0)
   { len++;

--- a/standalone/progs.d/nqfns.c
+++ b/standalone/progs.d/nqfns.c
@@ -87,8 +87,9 @@ ingp (int inp)
     { fscanf(ip,"%hd",&nng);
       for (i=1;i<=nng;i++) fscanf(ip,"%hd",nd1+i);
       for (i=1;i<=nng;i++) fscanf(ip,"%hd",nd2+i);
-      if (stage==4) {jump=exp*dim; pcpj=pcp+jump;}
+      if (stage==4) {jump=exp*dim; pcpj=pcp+jump;} else {jump=0; pcpj=NULL;}
     }
+    else {jump=0; pcpj=NULL;}
     for (i=exp+1;i<=exp+dim;i++)
     { comptr[i]=pcp-1;
       if (stage==4) powptr[i]=pcpj-1;
@@ -160,7 +161,7 @@ outgp (void)
   { for (i=1;i<=sum;i++) fprintf(op," %3d",dpth[i]); fprintf(op,"\n");}
   for (i=1;i<=sum;i++) fprintf(op," %3d",d1[i]); fprintf(op,"\n");
   for (i=1;i<=sum;i++) fprintf(op," %3d",d2[i]); fprintf(op,"\n");
-  jtl=0; pcp=pcptr;
+  jtl=0; pcp=pcptr; e=NULL;
   while (pcp<=pcb)
   { b= *pcp; c= tails ? *(pcp+1) : 0;
     if (b!=0) { k= *(*pcp-1); l= **pcp; e=b+l; }
@@ -457,10 +458,10 @@ bgc (void)
   printf("Back garbage collection. wsp=%d.\n",wsp);
   fflush(stdout); fflush(stderr);
   wt=fopen(gcfile,"w");
-  if (stage>=2) { pcp=pcb+1; epcp= (stage>2) ? npcb2 : npcb; d=1;}
+  if (stage>=2) { pcp=pcb+1; ct=0; epcp= (stage>2) ? npcb2 : npcb; d=1;}
   else
   if (stage==1) { pcp=opcb+facexp+1; ct=facexp+1; epcp=pcb; d=1;}
-  else { pcp=pcptr; epcp=pcb; d=0;}
+  else { pcp=pcptr; ct=0; epcp=pcb; d=0;}
   while (pcp<=epcp)
   { if (stage==0) pcp++; if ((p=  *pcp)!=0)
     { q=p+ *p; p-=(1+d); while (++p<=q) fprintf(wt,"%d ",*p); }
@@ -589,7 +590,7 @@ prnrel (void)
 */
 { int i,j,k,l,nl,w,x,y,ct,elno,fac,pow,len,gno; short *p,*q,*eprvec,**dp,**edp;
   char sub,triv,gth,u;
-  u= (stage) ? 1 : 0; pow=0; len=0;
+  u= (stage) ? 1 : 0; pow=0; len=0; gno=0;
   for (i=nng;i>=1;i--) if ((x=nexpnt[i])!=0)
   { len++;
     if (pow==0 || (stage==0 && wt[i+exp]<w)) {pow=x; gno=i; w=wt[i+exp];}
@@ -611,10 +612,10 @@ prnrel (void)
   }
   /* else printf("New gen no %d is eliminated.\n",gno); */
   eprvec=prvec+nng;  elno= (u) ? gno : exp+gno;
-  if (stage>=2) { dp=pcb+1; edp= (stage>2) ? npcb2 : npcb;}
+  if (stage>=2) { dp=pcb+1; ct=0; edp= (stage>2) ? npcb2 : npcb;}
   else
   if (stage==1) { dp=opcb+facexp+1; ct=facexp+1; edp=pcb;}
-  else { dp=pcptr; edp=pcb; }
+  else { dp=pcptr; ct=0; edp=pcb; }
 /* Now we edit the PCP relations, wasting as little space as possible */
   while (dp<=edp)
   { p= *dp;

--- a/standalone/progs.d/nqmfns.c
+++ b/standalone/progs.d/nqmfns.c
@@ -85,7 +85,7 @@ ingp (void)
   fclose(ip); return(0);
 }
 
-int 
+void
 outgp (void)
 /* The PCP is output, together with tails */
 { short i,k,l,**pcp,*b,*e,*c;
@@ -119,11 +119,11 @@ outgp (void)
   fclose(op);
 }
 
-int 
+void
 zero (short *p1, short *p2)
 { while ((++p1)<=p2) *p1=0; }
 
-int 
+void
 setnr (short *p)
 /* This is called only by collect, which follows */
 { short *p1,*p2,*c;

--- a/standalone/progs.d/nqmfns.c
+++ b/standalone/progs.d/nqmfns.c
@@ -306,6 +306,7 @@ prnrel (int corrtl)
 */
 { short i,j,k,len,hp,ct,fac,x,y,a,b,c,hpi,gno,*p,**dp,term[30];
    char elim,sub,rep,triv;
+   a=0; b=0; gno=0;
 restart:
   hp=exp/2; len=0; rep=0;
   for (i=nng;i>=1;i--)

--- a/standalone/progs.d/nqmfns.c
+++ b/standalone/progs.d/nqmfns.c
@@ -246,7 +246,7 @@ subrel (int i, int j)
 /* The element currently in nexpnt, is introduced as the tail of the relation
    [i,j]
 */
-{ short **dp,*p,*nrpb,sum;
+{ short **dp,*p,*nrpb;
   if (i==j) dp=powptr[i];  else dp=comptr[i]+2*j;
   if (*dp != 0 && *(*dp-1) != 0)
   { printf("Reln [%d,%d] is already a defn.\n",i,j); return(0);}
@@ -268,7 +268,7 @@ assoc (int g1, int g2, int g3)
    later. If g1=g2, we use (g1^p)g2 and g1(g1^(p-1)g2), and similarly if
    g2=g3.
 */
-{ char eq12,eq23,prnt,triv; short i,l,e,*p;
+{ char eq12,eq23,prnt,triv; short i,e,*p;
   if (g3<0) {prnt=1; g3= -g3;} else prnt=0;
   eq12= g1==g2; eq23= g2==g3 && g1!=g2;
   zero(nexpnt,enexpnt); zero(expnt,eexpnt);

--- a/standalone/progs.d/nqmfns.c
+++ b/standalone/progs.d/nqmfns.c
@@ -338,16 +338,22 @@ restart:
     while (++dp<=pcb)
     { p= *dp; if (p!=0)
       { y=p[gno];
-        if (y!=0) for (j=1;j<=nng;j++) if (j==gno) continue;
-        else if ((k=nexpnt[j])!=0) {p[j]-=(y*k); p[j]%=cord[j]; }
+        if (y!=0)
+        { for (j=1;j<=nng;j++) if (j==gno) continue;
+          else if ((k=nexpnt[j])!=0) {p[j]-=(y*k); p[j]%=cord[j]; }
+	}
       }
       dp++;
     }
-    if (corrtl) for (i=3;i<=intexp;i++) if ((p=tlintg[i])!=0)
-    { y=p[gno];
-      if (y!=0) for (j=1;j<=nng;j++) if (j==gno) continue;
-      else
-      if ((k=nexpnt[j])!=0) {p[j]-=(y*k); p[j]%=cord[j]; }
+    if (corrtl)
+    { for (i=3;i<=intexp;i++) if ((p=tlintg[i])!=0)
+      { y=p[gno];
+        if (y!=0)
+	{ for (j=1;j<=nng;j++) if (j==gno) continue;
+          else
+          if ((k=nexpnt[j])!=0) {p[j]-=(y*k); p[j]%=cord[j]; }
+	}
+      }
     }
     a=cord[gno]; p=nexpnt;
     while (++p<=enexpnt)

--- a/standalone/progs.d/nqmp.c
+++ b/standalone/progs.d/nqmp.c
@@ -32,8 +32,8 @@ FILE *ip,*op;
 */
 int 
 nqmprog (void)
-{ short i,j,k,l,m,d,*gi,*gj,*ti,*tj,cl,def,*ps,*pf,**dp,*nrpb,*p,*orpf,*orpb,
-        nb,np,k1,*rno,*covrel,**pgen,tdef,sgn;
+{ short i,j,k,l,m,*gi,*gj,*ti,*tj,cl,def,*ps,*pf,**dp,*nrpb,*p,*orpf,*orpb,
+        nb,np,k1,*rno,*covrel,**pgen,sgn;
   char nt;
   if (ingp() == -1) {fprintf(stderr,"Input error.\n"); return(-1); }
   covrel=NULL; eexpnt=expnt+exp; enexpnt=nexpnt+nng;

--- a/standalone/progs.d/nqmp.c
+++ b/standalone/progs.d/nqmp.c
@@ -36,7 +36,7 @@ nqmprog (void)
         nb,np,k1,*rno,*covrel,**pgen,tdef,sgn;
   char nt;
   if (ingp() == -1) {fprintf(stderr,"Input error.\n"); return(-1); }
-  eexpnt=expnt+exp; enexpnt=nexpnt+nng;
+  covrel=NULL; eexpnt=expnt+exp; enexpnt=nexpnt+nng;
 
 /* if nng=0, we are computing the multiplier of P. First we estimate the
    maximal possible no of new gens, mnng.

--- a/standalone/progs.d/nqp1.c
+++ b/standalone/progs.d/nqp1.c
@@ -44,7 +44,7 @@ FILE *ip,*ipm,*op;
 
 int 
 nqprog (void)
-{ short i,c,**p,**q,*r,ct,oexp; char adn;
+{ short i,c,**p,**q,ct,oexp; char adn;
   if (cfm)
 /* Calculate Frattini module only  */
   { tails=1; stage=0; strcpy(outf1,outf0);
@@ -275,7 +275,7 @@ calcfm (int steps)
    Frattini extension, but this is only used for testing.
    At each stage, the NQA is applied to the group computed so far.
 */
-{ short i,j,k,l,d,cl,st,dp,bd,ed; char inp;
+{ short i,j,k,l,cl,st,dp,bd,ed; char inp;
   printf("Computing Frattini module to depth %d.\n",steps);
   st=1; depth= -1; inp= act ? 0 : 1;
 /* if inp=0, initial input is from inf3 (which is already open as ip);

--- a/standalone/progs.d/nqp2.c
+++ b/standalone/progs.d/nqp2.c
@@ -224,10 +224,11 @@ spact (void)
     for (i=1;i<=facexp;i++) for (j=i;j<=facexp;j++) for (k=exp+1;k<=exp+dim;k++)
     if ((i==j && wt[i]+1+wt[k]==cl) || (i!=j && wt[i]+wt[j]+wt[k]==cl))
     if (assoc(k,j,i))
-    if (ch1)
-    { if ((l=prnrel())==0) goto ncl; if (l== -1) return(-1); }
-    else
-    { l=prnrel(); if (l== -1) return(-1); if (l>1) nchg(); }
+    { if (ch1)
+      { if ((l=prnrel())==0) goto ncl; if (l== -1) return(-1); }
+      else
+      { l=prnrel(); if (l== -1) return(-1); if (l>1) nchg(); }
+    }
 ncl:;
   }
   if (ch1) printf("Cohomology grp has dim %d\n",nng);

--- a/standalone/progs.d/nqp2.c
+++ b/standalone/progs.d/nqp2.c
@@ -96,7 +96,7 @@ nchg (void)
 int 
 spact (void)
 /* Computes cohomology group H^i(P,M) or H^i(Q,M) */
-{ short i,j,k,l,m,n,ie,ct,cl,fg,wi,wj,*p,*q,*r,*nrpf,*v1,*v2,
+{ short i,j,k,l,m,ie,ct,cl,fg,wi,wj,*p,*q,*nrpf,*v1,*v2,
   **swop,homcl,c;
   char inp;
   inp= (ch1 && act) ? 0 : 1;
@@ -250,7 +250,7 @@ int
 intact (void)
 /* In case act, appropriate quotient of H^i(P,M) is computed */
 { short a,b,c,d,i,j,k,l,len,m,n,x,f1,f2,*p,*p1,*q,*q1,*r,*r1,*ia,*ib,*v1,
-        **bim,**cbim,**imcg,**cimcg,**dp,*null;
+        **bim,**cbim,**imcg,**cimcg,*null;
   char pow,nz;
   strcpy(inf1,inf0);
   if (norm)

--- a/standalone/progs.d/pcp.c
+++ b/standalone/progs.d/pcp.c
@@ -36,7 +36,7 @@ setfixb (short *p)
 
 int 
 pcprog (void)
-{ short i,j,k,l,m,n,mxp,ngads,pairs,class,hgen,coeff,nf,nf1,nf2,pt,*pk,
+{ short i,j,k,l,m,n,mxp,ngads,class,hgen,coeff,nf,nf1,nf2,pt,*pk,
         *pnf,*pnf1,*pnf2,*ipnf,*ipnf1,*p1,*p2,*ip1,*ip2,nwt;
   int quot;
   char diff;

--- a/standalone/progs.d/pcp.c
+++ b/standalone/progs.d/pcp.c
@@ -27,7 +27,7 @@ resetsv (void)
   return(0);
 }
 
-int 
+void
 setfixb (short *p)
 { short bno; bno=1;
   while (bno<=nb && p[base[bno]]==base[bno]) bno++;

--- a/standalone/progs.d/pcscfns.c
+++ b/standalone/progs.d/pcscfns.c
@@ -10,7 +10,7 @@ extern short npt,nb,npt1,exp,prime,pinv[],cp[],power[],wt[],base[],
    Then we have g(i)=h(i)^x * k, with k in P(i-1), and the exponent x is
    stored as power[i].
 */
-int 
+void
 firstgen (short *p, short *hg, short *co)
 /* Let the perm p be  g(i)^t * k with k in H(i-1). This procedure computes i
    and t, and returns them as *hg and *co.
@@ -52,7 +52,7 @@ express (short *p, short *relc, int nwt)
   return(0);
 }
 
-int 
+void
 setpinv (void)
 { short i,j;
   for (i=0;i<prime;i++) pinv[i]=0;

--- a/standalone/progs.d/readrels.c
+++ b/standalone/progs.d/readrels.c
@@ -263,7 +263,7 @@ int readrel (int no)
 */
 { short stbr,endbr,exp,l,m,n,ptr,ch,len;
   char gotg,br,clbr,emptybr;
-  gotg=0; br=0; clbr=0; ptr=0; len=0;
+  gotg=0; br=0; clbr=0; emptybr=0; stbr=0; endbr=0; ptr=0; len=0;
   ch=getc(ip);
   while (ch!='\n')
   { if (ch==' ') ch=getc(ip);

--- a/standalone/progs.d/readrels.c
+++ b/standalone/progs.d/readrels.c
@@ -32,7 +32,8 @@ static void snl_iop (void) { while (getc(iop)!='\n'); }
 
 int main (int argc, char *argv[])
 { short i,j,k,l,n,np,nb,ng,nsg,nr,ch,dim,ngext,nrext,rno,ct;
-  char c,err,arg,mult,append,split;
+  char c,err,mult,append,split;
+  int arg;
   gap=err=append=mult=split=0; arg=1;
   while (argv[arg][0]=='-')
   { if (argv[arg][1]=='a') append=1;

--- a/standalone/progs.d/scd.c
+++ b/standalone/progs.d/scd.c
@@ -27,7 +27,7 @@ int psp=PSP,svsp=SVSP;
 int 
 main (int argc, char *argv[])
 { short arg;  char c,err,ondef;
-  err=0; arg=1; subgp=0; mult=0; if (argc<=arg) {err=1; goto error;}
+  err=0; ondef=0; arg=1; subgp=0; mult=0; if (argc<=arg) {err=1; goto error;}
   while (argv[arg][0]=='-')
   { c=argv[arg][1];
     if (c=='s')

--- a/standalone/progs.d/scd.c
+++ b/standalone/progs.d/scd.c
@@ -42,15 +42,17 @@ main (int argc, char *argv[])
   }
   strcpy(inf1,argv[arg]);strcat(inf1,".");strcpy(inf2,inf1);strcpy(outf,inf1);
   strcpy(outft,inf1); strcat(outft,"dcrt");
-  if (subgp) if (subgp==1)
-  { strcpy(inf3,inf1); strcpy(inf4,inf1);
-    if (ondef==0)
-    { arg++; if (argc<=arg) strcat(inf3,"sg1"); else strcat(inf3,argv[arg]);
-      arg++; if (argc<=arg) strcat(inf4,"cr1"); else strcat(inf4,argv[arg]);
+  if (subgp)
+  { if (subgp==1)
+    { strcpy(inf3,inf1); strcpy(inf4,inf1);
+      if (ondef==0)
+      { arg++; if (argc<=arg) strcat(inf3,"sg1"); else strcat(inf3,argv[arg]);
+        arg++; if (argc<=arg) strcat(inf4,"cr1"); else strcat(inf4,argv[arg]);
+      }
+      else { strcat(inf4,"cr1"); strcat(inf3,"sg1"); }
     }
-    else { strcat(inf4,"cr1"); strcat(inf3,"sg1"); }
+    else strcpy(inf0,inf1);
   }
-  else strcpy(inf0,inf1);
   arg++; if (argc<=arg) strcat(outf,"sc"); else strcat(outf,argv[arg]);
   arg++; if (argc<=arg) strcat(inf2,"dcr"); else strcat(inf2,argv[arg]);
   arg++; if (argc<=arg) strcat(inf1,"spc"); else strcat(inf1,argv[arg]);

--- a/standalone/progs.d/scp.c
+++ b/standalone/progs.d/scp.c
@@ -16,9 +16,9 @@ FILE *ip,*ipcr,*ipkp,*op,*opy;
 
 int 
 scprog (void)
-{ short i,j,k,l,m,n,stconj,np,pm1,ncr,crct,ndc,dcct,
+{ short i,j,k,l,m,n,stconj,pm1,ncr,crct,ndc,dcct,
         lo,intexsk,stpt,lpt,stint,olen,pt,ad,*p1,*ip1,*p2,*ip2,
-        *pint,*ptr,*g,*ig,ino,olo,**vsvptr;
+        *pint,*ptr,olo,**vsvptr;
   int quot;
   char  ingp,igth;
 

--- a/standalone/progs.d/sylp.c
+++ b/standalone/progs.d/sylp.c
@@ -23,7 +23,7 @@ FILE *ip,*op;
 int 
 sylprog (void)
 { char nontriv,bt,seek,b,incadno;
-  short i,j,k,l,m,n,lnt,fnt,mxp,mnb,mexp,nperms,nb,ct,np2,bno,stp,
+  short i,j,k,l,lnt,fnt,mxp,mexp,nperms,nb,ct,np2,bno,stp,
         lexp,*z,*itp,*ap,*sva;
   int quot;
   if ((ip=fopen(inf,"r"))==0)

--- a/standalone/progs.d/sylp.c
+++ b/standalone/progs.d/sylp.c
@@ -89,7 +89,7 @@ sylprog (void)
     if (l>1) for (j=1;j<=npt;j++) if (svgptr[i][j]>0)
     { k++; expptr[k]=z; z+=npt; exprep(j,k,svgptr[i]); }
   }
-  nontriv=0; *pno=0; deftime[0]=0; stp=np2+1;
+  bt=0; nontriv=0; *pno=0; deftime[0]=0; stp=np2+1;
   for (i=1;i<=nb;i++)
   { for (j=1;j<=npt;j++) {svpptr[i][j]=0; svpptr[i][base[i]]= -1; }
     lorbdef[i]=1;


### PR DESCRIPTION
You don't necessarily want to merge this.  I intend this as a conversation starter.  I noticed the comment in Makefile.in about reimplementing.  I've dealt with old code before.  In some cases, I have reimplemented, and in other cases have made incremental improvements to the code.  In my experience, the latter requires less work overall.  Reimplementations inevitably introduce bugs, often breaking boundary or corner cases, and often sacrifice functionality that is too much work to reimplement right away.  The effort required to debug and cover 100% of the original functionality is often much greater than people anticipate when starting such an effort.

Incremental improvements, on the other hand, can be a series of small steps, each of which pushes the code base in the desired direction.  By taking 1 small step at a time, it is easier to ensure correctness of the changes, and no functionality must be sacrificed.

If the incremental improvement approach seems interesting, then I offer these 5 commits as examples of what can be done.  My preference would be to _not_ merge them as is, though.  It is up to the maintainers of this code, but I would much rather have somebody choose a modern indentation style and run GNU indent or a similar tool over the entire code base first.  That will change many lines, rendering git history mostly useless, so it would be good to do that first, so that the later incremental changes are part of the more recent history.  At the very least, I would like to see an end to the practice of cramming multiple statements onto a single line.  I think that makes the code harder to read.  (Ending that practice would have the nice side effect of eliminating most or all of the warnings generated by -Wmisleading-indentation, which is implied by -Wall in recent versions of gcc.)

If you prefer not to reindent the code, then by all means, please consider these commits for merging.

Note: the first commit, to eliminate -Wreturn-type warnings, is bigger than you might expect because I moved function definitions above their first uses.  That will help later with elimination of -Wimplicit-function-declaration warnings.  It also may help the optimizer a bit.