### PR TITLE
Enable coverage tracking for standalone code

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -8,7 +8,7 @@ CFLAGS ?= -O2 -g
 
 # many cohomolo symbols (e.g. 'exp') clash with C builtins,
 # so we disable them to avoid spurious warnings and errors
-EXTRA_CFLAGS += -fno-builtin
+EXTRA_CFLAGS += -fno-builtin -g
 
 # evil HACK: disable some warnings to prevent CI build log overflow.
 # FIXME: these warnings really should be fixed instead, but that's

--- a/Makefile.in
+++ b/Makefile.in
@@ -10,14 +10,12 @@ CFLAGS ?= -O2 -g
 # so we disable them to avoid spurious warnings and errors
 EXTRA_CFLAGS += -fno-builtin
 
-# evil HACK: disable some warnings, to prevent an overflowing build
-# log on Travis.
+# evil HACK: disable some warnings to prevent CI build log overflow.
 # FIXME: these warnings really should be fixed instead, but that's
 # very hard and unrewarding word on this old code base. It's more
 # tempting to reimplement this all in scratch in a modern C or C++,
-# or a radically different language (Ruse, Go, Julia, ...)
+# or a radically different language (Rust, Go, Julia, ...)
 EXTRA_CFLAGS += -Wno-implicit-function-declaration
-EXTRA_CFLAGS += -Wno-unused-result
 
 all:
 	mkdir -p bin/@GAPARCH@;

--- a/gap/coho4.g
+++ b/gap/coho4.g
@@ -19,7 +19,7 @@ BindGlobal("COHOMOLO", rec(
                  CoDim2     := 0,
                  RelVals    := [],
                  PermRels   := [],
-                 RM_F       := "rm -f ",
+                 RM_F       := "rm -f ", # FIXME: this could be a problem on Cygwin
                  CALL       := DirectoriesPackagePrograms("cohomolo")
                  #This is the directory of the external executables
                 ) );


### PR DESCRIPTION
UPDATE: it turns out that `--coverage` is already being passed to the compiler for the relevant C files. Still, no coverage data is produced for them. Based on the logs, the problem might be that gcov / codecov can't find the C source files (they sit in a completely different path compared to the package's bin path